### PR TITLE
Nodes should run start() after a previous run returned RUNNING. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BehaviorTree.js
 
-A JavaScript implementation of Behavior Trees. They are useful for implementing AIs. If you need more information about Behavior Trees, look on [GameDevAI](http://aigamedev.com), there is a nice [video about Behavior Trees from Alex Champandard](http://aigamedev.com/open/article/behavior-trees-part1/). There is also a nice read of [Björn Knafla](http://www.altdevblogaday.com/author/bjoern-knafla/) explaining how [explaining how Behavior Trees work](http://www.altdevblogaday.com/2011/02/24/introduction-to-behavior-trees/).
+A JavaScript implementation of Behavior Trees. They are useful for implementing AIs. If you need more information about Behavior Trees, look on [GameDevAIPro](https://www.gameaipro.com), there is a nice [article on Behavior Trees from Alex Champandard and Philip Dunstan](https://www.gameaipro.com/GameAIPro/GameAIPro_Chapter06_The_Behavior_Tree_Starter_Kit.pdf).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ import { Task, SUCCESS } from 'behaviortree'
 const myTask = new Task({
   // (optional) this function is called directly before the run method
   // is called. It allows you to setup things before starting to run
-  // Beware: if task is resumed after calling this.running(), start is not called.
   start: function(blackboard) { blackboard.isStarted = true; },
 
   // (optional) this function is called directly after the run method

--- a/src/BehaviorTree.spec.js
+++ b/src/BehaviorTree.spec.js
@@ -453,9 +453,9 @@ describe('BehaviorTree', () => {
         end3: 0
       }
 
-      bTree = new BehaviorTree({
+      const bTree = new BehaviorTree({
         tree: sequence,
-        blackboard: blackboard
+        blackboard
       })
 
       bTree.step()

--- a/src/BehaviorTree.spec.js
+++ b/src/BehaviorTree.spec.js
@@ -394,4 +394,113 @@ describe('BehaviorTree', () => {
       expect(selectorNodes.map(x => x.result)).toEqual([false, false, false, true, undefined])
     })
   })
+  describe('behavior with running nodes', () => {
+    it('calls start of all task where appropriate', () => {
+      const task1 = new Task({
+        start: function (blackboard) {
+          ++blackboard.start1
+        },
+        end: function (blackboard) {
+          ++blackboard.end1
+        },
+        run: function (blackboard) {
+          ++blackboard.run1
+          return SUCCESS
+        }
+      })
+      const task2 = new Task({
+        start: function (blackboard) {
+          ++blackboard.start2
+        },
+        end: function (blackboard) {
+          ++blackboard.end2
+        },
+        run: function (blackboard) {
+          ++blackboard.run2
+          return blackboard.task2Result
+        }
+      })
+      const task3 = new Task({
+        start: function (blackboard) {
+          ++blackboard.start3
+        },
+        end: function (blackboard) {
+          ++blackboard.end3
+        },
+        run: function (blackboard) {
+          ++blackboard.run3
+          return SUCCESS
+        }
+      })
+
+      const sequence = new Sequence({
+        nodes: [
+          task1,
+          task2,
+          task3
+        ]
+      })
+      const blackboard = {
+        task2Result: RUNNING,
+        start1: 0,
+        run1: 0,
+        end1: 0,
+        start2: 0,
+        run2: 0,
+        end2: 0,
+        start3: 0,
+        run3: 0,
+        end3: 0
+      }
+
+      bTree = new BehaviorTree({
+        tree: sequence,
+        blackboard: blackboard
+      })
+
+      bTree.step()
+
+      expect(blackboard.start1).toEqual(1)
+      expect(blackboard.run1).toEqual(1)
+      expect(blackboard.end1).toEqual(1)
+
+      expect(blackboard.start2).toEqual(1)
+      expect(blackboard.run2).toEqual(1)
+      expect(blackboard.end2).toEqual(0)
+
+      expect(blackboard.start3).toEqual(0)
+      expect(blackboard.run3).toEqual(0)
+      expect(blackboard.end3).toEqual(0)
+
+      bTree.step()
+
+      expect(blackboard.start1).toEqual(1)
+      expect(blackboard.run1).toEqual(1)
+      expect(blackboard.end1).toEqual(1)
+
+      expect(blackboard.start2).toEqual(1)
+      expect(blackboard.run2).toEqual(2)
+      expect(blackboard.end2).toEqual(0)
+
+      expect(blackboard.start3).toEqual(0)
+      expect(blackboard.run3).toEqual(0)
+      expect(blackboard.end3).toEqual(0)
+
+      blackboard.task2Result = SUCCESS
+
+      bTree.step()
+
+      expect(blackboard.start1).toEqual(1)
+      expect(blackboard.run1).toEqual(1)
+      expect(blackboard.end1).toEqual(1)
+
+      expect(blackboard.start2).toEqual(1)
+      expect(blackboard.run2).toEqual(3)
+      expect(blackboard.end2).toEqual(1)
+
+      expect(blackboard.start3).toEqual(1)
+      expect(blackboard.run3).toEqual(1)
+      expect(blackboard.end3).toEqual(1)
+    })
+  })
 })

--- a/src/BranchNode.js
+++ b/src/BranchNode.js
@@ -8,6 +8,7 @@ export default class BranchNode extends Node {
     super(blueprint)
 
     this.numNodes = blueprint.nodes.length
+    this.wasRunning = false
   }
 
   run (blackboard = null, { indexes = [], rerun, runData, registryLookUp = x => x } = {}) {
@@ -19,6 +20,7 @@ export default class BranchNode extends Node {
       let node = registryLookUp(this.blueprint.nodes[currentIndex])
       const result = node.run(blackboard, { indexes, rerun, runData: subRunData, registryLookUp })
       if (result === RUNNING) {
+        this.wasRunning = true
         return [ currentIndex, ...indexes ]
       } else if (typeof result === 'object') { // array
         return [ ...indexes, currentIndex, ...result ]
@@ -26,6 +28,10 @@ export default class BranchNode extends Node {
         overallResult = result
         break
       } else {
+        if (this.wasRunning) {
+          this.wasRunning = false
+          rerun = false
+        }
         ++currentIndex
       }
     }


### PR DESCRIPTION
The `rerun` variable is set via the root of the tree when `step()` runs, however, when a RUNNING node has finished, the next task in the tree will not run `start()`. This shouldn't happen.

Also updated reference docs ... the current ones are all gone, unfortunately. The text can still be read via waybackmachine, but the updated link is perfect for this project (also by Alex Champandard).